### PR TITLE
fix: Multiple bugs in devices page and map module

### DIFF
--- a/api/map-update-item.php
+++ b/api/map-update-item.php
@@ -68,9 +68,16 @@ switch ($itemType) {
 
     case 'odc':
         $portCount = $data['port_count'] ?? 4;
+        $serverId = !empty($data['server_id']) ? (int)$data['server_id'] : null;
 
-        $stmt = $conn->prepare("UPDATE odc_config SET port_count = ? WHERE map_item_id = ?");
-        $stmt->bind_param("ii", $portCount, $itemId);
+        // Update port_count in odc_config
+        $stmt = $conn->prepare("UPDATE odc_config SET port_count = ?, server_id = ? WHERE map_item_id = ?");
+        $stmt->bind_param("iii", $portCount, $serverId, $itemId);
+        $stmt->execute();
+
+        // Update parent_id in map_items
+        $stmt = $conn->prepare("UPDATE map_items SET parent_id = ? WHERE id = ?");
+        $stmt->bind_param("ii", $serverId, $itemId);
         $stmt->execute();
         break;
 
@@ -84,6 +91,12 @@ switch ($itemType) {
         $useSecondarySplitter = $data['use_secondary_splitter'] ?? 0;
         $secondarySplitterRatio = $data['secondary_splitter_ratio'] ?? null;
         $customSecondaryRatioOutputPort = $data['custom_secondary_ratio_output_port'] ?? null;
+        $parentId = !empty($data['parent_id']) ? (int)$data['parent_id'] : null;
+
+        // Update parent_id in map_items
+        $stmtParent = $conn->prepare("UPDATE map_items SET parent_id = ? WHERE id = ?");
+        $stmtParent->bind_param("ii", $parentId, $itemId);
+        $stmtParent->execute();
 
         // Recalculate power based on updated splitter configuration
         $calculator = new PONCalculator();
@@ -109,7 +122,7 @@ switch ($itemType) {
         }
 
         $stmt = $conn->prepare("UPDATE odp_config SET port_count = ?, odc_port = ?, parent_odp_port = ?, use_splitter = ?, splitter_ratio = ?, custom_ratio_output_port = ?, use_secondary_splitter = ?, secondary_splitter_ratio = ?, custom_secondary_ratio_output_port = ?, calculated_power = ? WHERE map_item_id = ?");
-        $stmt->bind_param("iisississsdi", $portCount, $odcPort, $parentOdpPort, $useSplitter, $splitterRatio, $customRatioOutputPort, $useSecondarySplitter, $secondarySplitterRatio, $customSecondaryRatioOutputPort, $calculatedPower, $itemId);
+        $stmt->bind_param("iisisssssdi", $portCount, $odcPort, $parentOdpPort, $useSplitter, $splitterRatio, $customRatioOutputPort, $useSecondarySplitter, $secondarySplitterRatio, $customSecondaryRatioOutputPort, $calculatedPower, $itemId);
         $stmt->execute();
         break;
 

--- a/assets/js/devices.js
+++ b/assets/js/devices.js
@@ -40,6 +40,11 @@ async function loadDevices(isAutoRefresh = false) {
         hasMore = firstChunk.hasMore;
         skip += chunkSize;
 
+        // Store map items for infrastructure tabs
+        if (mapItemsResult && mapItemsResult.success) {
+            allMapItems = mapItemsResult.items || [];
+        }
+
         // Update UI with first chunk immediately
         if (!isAutoRefresh) {
             tbody.innerHTML = '<tr><td colspan="12" class="text-center"><div class="spinner"></div><div style="margin-top: 10px;">Loading devices... (' + allDevices.length + ' loaded)</div></td></tr>';

--- a/assets/js/map/map-core.js
+++ b/assets/js/map/map-core.js
@@ -99,36 +99,33 @@ function initMap() {
     // Start initialization with short delay to allow script loading
     setTimeout(initEditable, 200);
 
-    // Base layers
-    const osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; OpenStreetMap contributors',
-        maxZoom: 19
+    // Base layers - Google Maps tiles (no API key required)
+    const googleStreet = L.tileLayer('https://mt{s}.google.com/vt/lyrs=m&x={x}&y={y}&z={z}', {
+        attribution: '&copy; Google Maps',
+        subdomains: ['0', '1', '2', '3'],
+        maxZoom: 22
     });
 
-    const satellite = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-        attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
-        maxZoom: 19
+    const googleSatellite = L.tileLayer('https://mt{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
+        attribution: '&copy; Google Maps',
+        subdomains: ['0', '1', '2', '3'],
+        maxZoom: 22
     });
 
-    const hybrid = L.layerGroup([
-        L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-            maxZoom: 19
-        }),
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}{r}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-            subdomains: 'abcd',
-            maxZoom: 19
-        })
-    ]);
+    const googleHybrid = L.tileLayer('https://mt{s}.google.com/vt/lyrs=y&x={x}&y={y}&z={z}', {
+        attribution: '&copy; Google Maps',
+        subdomains: ['0', '1', '2', '3'],
+        maxZoom: 22
+    });
 
-    // Add default layer
-    hybrid.addTo(map);
+    // Add default layer (Hybrid paling detail)
+    googleHybrid.addTo(map);
 
     // Layer control
     const baseLayers = {
-        "OpenStreetMap": osm,
-        "Satelit": satellite,
-        "Hybrid (Satelit + Jalan)": hybrid
+        "Google Maps (Jalan)": googleStreet,
+        "Google Satelit": googleSatellite,
+        "Google Hybrid (Satelit + Jalan)": googleHybrid
     };
 
     L.control.layers(baseLayers, null, { position: 'topright' }).addTo(map);

--- a/assets/js/map/map-items.js
+++ b/assets/js/map/map-items.js
@@ -949,7 +949,23 @@ async function updateEditItemForm(item) {
             `;
             break;
         case 'odc':
+            // Load servers for parent assignment
+            const serversResultOdc = await fetchAPI('/api/map-get-items.php');
+            const allServersOdc = serversResultOdc?.success ? serversResultOdc.items.filter(i => i.item_type === 'server') : [];
+            let serverOptionsOdc = '<option value="">No Parent (Standalone)</option>';
+            allServersOdc.forEach(s => {
+                const selected = item.config?.server_id == s.id ? 'selected' : '';
+                serverOptionsOdc += `<option value="${s.id}" ${selected}>${s.name}</option>`;
+            });
+
             dynamicFields.innerHTML = `
+                <div class="form-group">
+                    <label>Parent Server</label>
+                    <select name="server_id" class="form-control">
+                        ${serverOptionsOdc}
+                    </select>
+                    <small class="text-muted">Assign ODC ke Server ini</small>
+                </div>
                 <div class="form-group">
                     <label>Port Count</label>
                     <input type="number" name="port_count" class="form-control" value="${item.config?.port_count || 4}" required>
@@ -957,7 +973,23 @@ async function updateEditItemForm(item) {
             `;
             break;
         case 'odp':
+            // Load ODCs for parent assignment
+            const itemsResultOdp = await fetchAPI('/api/map-get-items.php');
+            const allOdcs = itemsResultOdp?.success ? itemsResultOdp.items.filter(i => i.item_type === 'odc') : [];
+            let odcOptionsOdp = '<option value="">No Parent</option>';
+            allOdcs.forEach(o => {
+                const selected = item.parent_id == o.id ? 'selected' : '';
+                odcOptionsOdp += `<option value="${o.id}" ${selected}>${o.name}</option>`;
+            });
+
             dynamicFields.innerHTML = `
+                <div class="form-group">
+                    <label>Parent ODC</label>
+                    <select name="parent_id" class="form-control">
+                        ${odcOptionsOdp}
+                    </select>
+                    <small class="text-muted">Assign ODP ke ODC ini</small>
+                </div>
                 <div class="form-group">
                     <label>ODC Port</label>
                     <input type="number" name="odc_port" class="form-control" value="${item.config?.odc_port || ''}" min="1" placeholder="Nomor port di ODC">
@@ -1015,7 +1047,9 @@ async function updateItem() {
         bootstrap.Modal.getInstance(document.getElementById('editItemModal')).hide();
         loadMap();
     } else {
-        showToast(result.message || 'Gagal mengupdate item', 'danger');
+        const errMsg = (result && result.message) ? result.message : 'Gagal mengupdate item. Cek koneksi server.';
+        showToast(errMsg, 'danger');
+        console.error('updateItem error:', result);
     }
 }
 

--- a/assets/js/map/map-server.js
+++ b/assets/js/map/map-server.js
@@ -282,13 +282,30 @@ async function manageServerLinks(itemId) {
     const config = item.config || {};
     const ponPorts = config.pon_ports || {};
 
-    // Load netwatch data for ISP and OLT links
+    // Load netwatch data for ISP links
     const netwatchResult = await fetchAPI('/api/map-get-netwatch.php');
     let netwatchOptions = '<option value="">No Link</option>';
     if (netwatchResult && netwatchResult.success && netwatchResult.netwatch) {
         netwatchResult.netwatch.forEach(nw => {
             netwatchOptions += `<option value="${nw.host}">${nw.host} - ${nw.comment || 'No comment'}</option>`;
         });
+    }
+
+    // Load OLT options from map items
+    const mapItemsResult = await fetchAPI('/api/map-get-items.php');
+    let oltOptions = '<option value="">No Link</option>';
+    if (mapItemsResult && mapItemsResult.success && mapItemsResult.items) {
+        const oltItems = mapItemsResult.items.filter(i => i.item_type === 'olt');
+        oltItems.forEach(olt => {
+            const oltUrl = olt.properties?.olt_link || olt.name;
+            oltOptions += `<option value="${oltUrl}">${olt.name} - ${oltUrl}</option>`;
+        });
+        // Also add from netwatch as fallback
+        if (netwatchResult && netwatchResult.success && netwatchResult.netwatch) {
+            netwatchResult.netwatch.forEach(nw => {
+                oltOptions += `<option value="${nw.host}">${nw.host} - ${nw.comment || 'No comment'}</option>`;
+            });
+        }
     }
 
     // Load GenieACS devices for MikroTik
@@ -308,7 +325,7 @@ async function manageServerLinks(itemId) {
 
     document.getElementById('isp-link-select').innerHTML = netwatchOptions;
     document.getElementById('mikrotik-device-select').innerHTML = genieacsOptions;
-    document.getElementById('olt-link-select').innerHTML = netwatchOptions;
+    document.getElementById('olt-link-select').innerHTML = oltOptions;
 
     // Set current values
     if (properties.isp_link) {

--- a/devices.php
+++ b/devices.php
@@ -165,11 +165,11 @@ include __DIR__ . '/views/layouts/header.php';
 
 <?php endif; ?>
 
+<?php include __DIR__ . '/views/layouts/footer.php'; ?>
+
 <script>
 // Global configuration
 window.GENIEACS_CONFIGURED = <?php echo $genieacsConfigured ? 'true' : 'false'; ?>;
 </script>
 <script src="/assets/js/devices/devices-state.js"></script>
 <script src="/assets/js/devices.js"></script>
-
-<?php include __DIR__ . '/views/layouts/footer.php'; ?>


### PR DESCRIPTION
## Bug Fixes

### 1. Devices page - Infrastructure tabs empty (ODP, ODC, OLT, Server)
- `allMapItems` was fetched but never stored after `Promise.all` in `loadDevices()`
- Fix: Added `allMapItems = mapItemsResult.items || []` after fetch

### 2. devices.php - Script load order
- `devices-state.js` was loaded before footer (Bootstrap not yet available)
- Fix: Moved script tags to after `include footer.php`

### 3. map-core.js - OpenStreetMap tiles not available in some regions
- Replaced OpenStreetMap + ArcGIS tiles with Google Maps tiles
- Now supports Street, Satellite, and Hybrid layers
- Increased maxZoom from 19 to 22

### 4. map-server.js - OLT dropdown empty in Manage Server Links
- OLT dropdown was only populated from Netwatch, not from map items
- Fix: Now also loads OLT items from `map-get-items.php`

### 5. map-items.js - Edit ODC/ODP missing parent assignment fields
- Edit form for ODC had no field to assign Parent Server
- Edit form for ODP had no field to assign Parent ODC
- Fix: Added parent dropdowns to both edit forms

### 6. map-update-item.php - HTTP 500 on ODP update
- `bind_param` type string mismatch ("iisississsdi" vs actual params)
- Fix: Corrected to "iisisssssdi"
- Also added `server_id` handling for ODC and `parent_id` for ODP